### PR TITLE
Add LUFS momentary bar alongside short-term meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ macOSにMasterLevelMeter.pluginをインストールする際、次のような�
 - RMS
 - Peak
 - Short LUFS (3秒 ITU-R BS.1770 K-weighted 処理)
+- Momentary LUFS (400ms ITU-R BS.1770 K-weighted)
 - K-weighting フィルタ:
 - 二段ハイパス (60Hz) + High-shelf (+4 dB @ ~1.7 kHz) 実装
 - -23 / -18 LUFS 強調目盛り
@@ -78,8 +79,9 @@ macOSにMasterLevelMeter.pluginをインストールする際、次のような�
 
   
 
-### Loudness (Short)
+### Loudness (Short / Momentary)
 - Short: 3000ms ウィンドウ平均エネルギー（ch 合算）→ -0.691 オフセット
+- Momentary: 400ms ウィンドウ平均エネルギー（ch 合算）→ -0.691 オフセット
 
 ---
 ## Qt 6 Usage
@@ -260,6 +262,7 @@ Click Open. From now on, the plugin will load automatically.
 - RMS
 - Peak
 - Short LUFS (3000 ms ITU-R BS.1770 K-weighted)
+- Momentary LUFS (400 ms ITU-R BS.1770 K-weighted)
 - K-weighting filter:
 - Two-stage high-pass (60 Hz) + high-shelf (+4 dB @ ~1.7 kHz)
 - Emphasis ticks at -23 / -18 LUFS
@@ -272,8 +275,9 @@ Click Open. From now on, the plugin will load automatically.
 3. K-weighting & sub-block processing (100 ms hop / 3000 ms window)
 4. A ~60 fps Qt timer calls `updateLevelsLR()` → triggers repaint
 
-### Loudness (Short)
+### Loudness (Short / Momentary)
 - Short: 3000 ms sliding window energy (summed channels) with -0.691 offset
+- Momentary: 400 ms sliding window energy (summed channels) with -0.691 offset
 
 ---
 ## Qt 6 Usage

--- a/src/level_calc.h
+++ b/src/level_calc.h
@@ -39,6 +39,8 @@ public:
     float getSmoothedLUFSShort() const;
     float getLUFSShortCh(size_t ch) const;
     float getSmoothedLUFSShortCh(size_t ch) const;
+    float getSmoothedLUFSMomentary() const;
+    float getSmoothedLUFSMomentaryCh(size_t ch) const;
 
 private:
     static constexpr size_t kMaxChannels = 8;
@@ -62,6 +64,8 @@ private:
     std::array<std::atomic<float>, kMaxChannels> lufs_short_ch_{};
     float smoothed_lufs_short_ = -120.0f;
     std::array<float, kMaxChannels> smoothed_lufs_short_ch_{};
+    float smoothed_lufs_m_ = -120.0f;
+    std::array<float, kMaxChannels> smoothed_lufs_m_ch_{};
     std::vector<std::deque<double>> recentSubblocksShort_;
     std::vector<double> rollingSubSumShort_;
 

--- a/src/meter_widget.h
+++ b/src/meter_widget.h
@@ -3,6 +3,7 @@
 #include <QtGlobal>
 #include <array>
 #include <cstdint>
+#include <limits>
 
 class QPainter;
 class QRect;
@@ -19,8 +20,8 @@ public:
     explicit MeterWidget(QWidget *parent = nullptr);
 
 public slots:
-    void updateLevels(float rms, float peak, float lufs);
-    void updateLevelsLR(float rmsL, float rmsR, float peakL, float peakR, float lufsL, float lufsR);
+    void updateLevels(float rms, float peak, float lufsShort, float lufsMomentary = std::numeric_limits<float>::quiet_NaN());
+    void updateLevelsLR(float rmsL, float rmsR, float peakL, float peakR, float lufsShort, float lufsMomentary);
     void setMixIndex(int index);
     void setStreamingTracksMask(uint32_t mask);
 
@@ -49,8 +50,8 @@ private:
     float rmsDbR_ = -120.0f;
     float peakDbL_ = -120.0f;
     float peakDbR_ = -120.0f;
-    float lufsDbL_ = -120.0f;
-    float lufsDbR_ = -120.0f;
+    float lufsDbShort_ = -50.0f;
+    float lufsDbMomentary_ = -50.0f;
 
     // 表示用スムージング
     float rmsSmoothDbL_ = -120.0f;
@@ -75,7 +76,7 @@ private:
     float dbFloor_ = -60.0f;
     float dbCeil_  = 0.0f;
     // LUFS 専用スケール（最適化: -45 .. 0 LUFS）
-    float lufsFloor_ = -45.0f;
+    float lufsFloor_ = -50.0f;
     float lufsCeil_  = 0.0f;
 
     // ユーティリティ
@@ -84,12 +85,13 @@ private:
     float clampDbToRange(float db, float floor, float ceil) const;
     int dbToPx(float db, int widthPx) const;
     int lufsToPx(float lufs, int widthPx) const;
+    int lufsToPxBar(float lufs, int widthPx) const;
     void drawDbScale(QPainter &p, const QRect &r) const;
     void drawLevelBar(QPainter &p, const QRect &r, float dbValue) const;
     void drawPeakMarker(QPainter &p, const QRect &r, float dbValue) const;
     void drawLufsBar(QPainter &p, const QRect &r, float lufsDb) const;
     void drawBgZones(QPainter &p, const QRect &r) const;
     // 下端の控えめ目盛りのみ（数字なし）：RMS/Peak=5dB刻み、LUFS=5LU刻み
-    void drawBottomTicksDb(QPainter &p, const QRect &r) const;
-    void drawBottomTicksLUFS(QPainter &p, const QRect &r) const;
+    void drawBottomTicksDb(QPainter &p, const QRect &scaleRect, int mapLeft, int mapWidth) const;
+    void drawBottomTicksLUFS(QPainter &p, const QRect &scaleRect, int mapLeft, int mapWidth) const;
 };

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -229,10 +229,10 @@ bool obs_module_load(void) {
         float rmsR = (chs >= 2) ? g_levelCalc.getRMSCh(1) : rmsL;
         float peakL = (chs >= 1) ? g_levelCalc.getPeakCh(0) : g_levelCalc.getPeak();
         float peakR = (chs >= 2) ? g_levelCalc.getPeakCh(1) : peakL;
-        // LUFSはIIRスムージング後のチャンネル別値を使う
-        float lufsL = (chs >= 1) ? g_levelCalc.getSmoothedLUFSShortCh(0) : g_levelCalc.getSmoothedLUFSShort();
-        float lufsR = (chs >= 2) ? g_levelCalc.getSmoothedLUFSShortCh(1) : lufsL;
-        g_meterWidget->updateLevelsLR(rmsL, rmsR, peakL, peakR, lufsL, lufsR);
+        // LUFSはチャンネル合算（マスター）の値を表示する
+        float lufsShort = g_levelCalc.getSmoothedLUFSShort();
+        float lufsMomentary = g_levelCalc.getSmoothedLUFSMomentary();
+        g_meterWidget->updateLevelsLR(rmsL, rmsR, peakL, peakR, lufsShort, lufsMomentary);
     });
     g_updateTimer->start(16); // ~60fps
 


### PR DESCRIPTION
## Summary
- extend the Qt meter layout to show separate short-term and momentary LUFS bars while preserving the summed single-bar styling
- expose smoothed momentary loudness readings from LevelCalc and feed them through the OBS timer callback to the widget
- update documentation to note the additional LUFS (M) display and ITU windowing
- align LUFS and dB tick mapping with the bar fill, use ceil for LUFS widths, and draw frames after fills so meter endpoints land exactly on their tick marks

## Testing
- cmake -S . -B build *(fails: missing libobs/Qt build dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daae3217c483218584ff03729364b4