### PR TITLE
Fix LUFS short-term accumulation and channel summing

### DIFF
--- a/src/level_calc.h
+++ b/src/level_calc.h
@@ -71,6 +71,7 @@ private:
 
     std::atomic<uint32_t> sampleRate_;
     size_t channels_ = 0;
+    std::array<size_t, 2> meterChans_{0, 1};
 
     // K-weighting フィルタ
     struct FirstOrderHP {


### PR DESCRIPTION
## Summary
- reuse the computed 100 ms block energies for both momentary and short-term LUFS windows
- restrict overall loudness summation to the left/right pair so mirrored mono no longer overshoots

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3c3a60ac8321a0834ed35ea0cb69