### PR TITLE
Simplify LUFS bars and smooth their motion

### DIFF
--- a/src/meter_widget.h
+++ b/src/meter_widget.h
@@ -52,6 +52,8 @@ private:
     float peakDbR_ = -120.0f;
     float lufsDbShort_ = -50.0f;
     float lufsDbMomentary_ = -50.0f;
+    float lufsSmoothDbShort_ = -50.0f;
+    float lufsSmoothDbMomentary_ = -50.0f;
 
     // 表示用スムージング
     float rmsSmoothDbL_ = -120.0f;
@@ -63,6 +65,8 @@ private:
     const float rmsReleaseSec_ = 0.30f;  // 300ms
     const float peakAttackSec_ = 0.04f;  // 40ms（少し遅く）
     const float peakReleaseSec_ = 0.25f; // 250ms
+    const float lufsAttackSec_ = 0.06f;
+    const float lufsReleaseSec_ = 0.30f;
 
     // ピークホールド（L/R）
     float peakHoldDbL_ = -120.0f;


### PR DESCRIPTION
## Summary
- render LUFS bars with a single zone color and remove unused zone logic
- smooth LUFS short-term and momentary readings to match the RMS/Peak animation cadence

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc66d764ac8321a3029e5db07b4900